### PR TITLE
changed RNA assay data to counts

### DIFF
--- a/R/2SingleCellExperiment_INPUT.R
+++ b/R/2SingleCellExperiment_INPUT.R
@@ -7,7 +7,7 @@ creatSCE<-function(seu){
   require(SingleCellExperiment)
   #load(wd)
   # input matrix
-  counts_data <- as.matrix(seu@assays$RNA@data)
+  counts_data <- as.matrix(seu@assays$RNA@counts)
   col<-seu@meta.data
   sce <- SingleCellExperiment(assays = list(counts = counts_data),colData = col)
   return(sce)


### PR DESCRIPTION
the @assays$RNA@data can store the normalized and transformed counts if logNormalization or scaleData was run. To ensure that you use the raw counts for the scds package (which is required especially for scds::bcds computation), it should be @assays$RNA@counts